### PR TITLE
adding relation prisma

### DIFF
--- a/prisma/migrations/20250910102803_add_relation/migration.sql
+++ b/prisma/migrations/20250910102803_add_relation/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "public"."_PostsToTags" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_PostsToTags_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_PostsToTags_B_index" ON "public"."_PostsToTags"("B");
+
+-- AddForeignKey
+ALTER TABLE "public"."Profiles" ADD CONSTRAINT "Profiles_UserId_fkey" FOREIGN KEY ("UserId") REFERENCES "public"."Users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Posts" ADD CONSTRAINT "Posts_ProfileId_fkey" FOREIGN KEY ("ProfileId") REFERENCES "public"."Profiles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_PostsToTags" ADD CONSTRAINT "_PostsToTags_A_fkey" FOREIGN KEY ("A") REFERENCES "public"."Posts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_PostsToTags" ADD CONSTRAINT "_PostsToTags_B_fkey" FOREIGN KEY ("B") REFERENCES "public"."Tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,8 @@ model Users {
   email    String @unique
   role     Role
 
+  profile Profiles?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -29,6 +31,8 @@ enum Role {
   USER
 }
 
+// one to one retation users hasOne profiles
+// one to many relation profiles hasMany posts
 model Profiles {
   id     Int    @id @default(autoincrement())
   name   String @unique
@@ -36,16 +40,22 @@ model Profiles {
   age    Int
   UserId Int    @unique
 
+  user  Users   @relation(fields: [UserId], references: [id])
+  posts Posts[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
 
+// many to many relation posts has many tags / tags has many posts
 model Posts {
-  id          Int     @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   titlePost   String
   picturePost String?
   captionPost String
   ProfileId   Int
+  author      Profiles @relation(fields: [ProfileId], references: [id])
+  tags        Tags[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -54,6 +64,8 @@ model Posts {
 model Tags {
   id      Int    @id @default(autoincrement())
   tagName String @unique
+
+  posts Posts[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
This pull request introduces new relationships between the core models in the Prisma schema to support richer associations between users, profiles, posts, and tags. The changes add one-to-one, one-to-many, and many-to-many relationships, update the schema accordingly, and include a new join table with appropriate foreign keys and indexes.

**Schema relationship enhancements:**

* Added a one-to-one relationship between `Users` and `Profiles` by introducing a `profile` field in `Users` and a corresponding `user` relation in `Profiles`. (`prisma/schema.prisma`) [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR23-R24) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR34-R58)
* Established a one-to-many relationship between `Profiles` and `Posts` by adding a `posts` field in `Profiles` and an `author` relation in `Posts`. (`prisma/schema.prisma`)
* Implemented a many-to-many relationship between `Posts` and `Tags` by adding a `tags` field in `Posts`, a `posts` field in `Tags`, and creating the join table `_PostsToTags` with the necessary foreign keys and index. (`prisma/schema.prisma`, `prisma/migrations/20250910102803_add_relation/migration.sql`) [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR34-R58) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR68-R69) [[3]](diffhunk://#diff-637193fd251e11ebf0f7162485977015ccbb4032612fd3c37dc987f43e3b24f0R1-R22)

**Database migration:**

* Created the `_PostsToTags` join table and added foreign key constraints to enforce the new relationships between `Users`, `Profiles`, `Posts`, and `Tags`. (`prisma/migrations/20250910102803_add_relation/migration.sql`)