### PR TITLE
chore: implement bcrypt for password hashing and user creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^6.15.0",
+        "bcrypt": "^6.0.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "zod": "^4.1.5"
@@ -24,6 +25,7 @@
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
@@ -2781,6 +2783,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -4125,6 +4137,20 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -7965,6 +7991,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -7981,6 +8016,17 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.15.0",
+    "bcrypt": "^6.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^4.1.5"
@@ -35,6 +36,7 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",

--- a/src/common/helpers/bcrypt/bcrypt.module.ts
+++ b/src/common/helpers/bcrypt/bcrypt.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { BcryptService } from './bcrypt.service';
+
+@Global()
+@Module({
+  providers: [BcryptService],
+  exports: [BcryptService],
+})
+export class BcryptModule {}

--- a/src/common/helpers/bcrypt/bcrypt.service.spec.ts
+++ b/src/common/helpers/bcrypt/bcrypt.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BcryptService } from './bcrypt.service';
+
+describe('BcryptService', () => {
+  let service: BcryptService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BcryptService],
+    }).compile();
+
+    service = module.get<BcryptService>(BcryptService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/common/helpers/bcrypt/bcrypt.service.ts
+++ b/src/common/helpers/bcrypt/bcrypt.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class BcryptService {
+  async hashPassword(plainPassword: string): Promise<string> {
+    const saltRounds = 10;
+    return bcrypt.hash(plainPassword, saltRounds);
+  }
+
+  async comparePassword(
+    plainPassword: string,
+    hashedPassword: string,
+  ): Promise<boolean> {
+    const isMatch = await bcrypt.compare(plainPassword, hashedPassword);
+    return isMatch;
+  }
+}

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -19,8 +19,12 @@ export class UsersController {
 
   @Post()
   @UsePipes(new ZodValidationPipe(createUserSchemaValidation))
-  create(@Body() createUserDto: Prisma.UsersCreateInput) {
-    return this.usersService.create(createUserDto);
+  async create(@Body() createUserDto: Prisma.UsersCreateInput) {
+    const result = await this.usersService.create(createUserDto);
+    return {
+      message: 'User created successfully',
+      user: result,
+    };
   }
 
   @Get()

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { PrismaModule } from 'src/common/helpers/db/prisma.module';
+import { BcryptModule } from 'src/common/helpers/bcrypt/bcrypt.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, BcryptModule],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,14 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { BcryptService } from 'src/common/helpers/bcrypt/bcrypt.service';
 import { PrismaService } from 'src/common/helpers/db/prisma.service';
 
 @Injectable()
 export class UsersService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private bcrypt: BcryptService,
+  ) {}
+
   async create(createUserDto: Prisma.UsersCreateInput) {
-    return await this.prisma.users.create({
-      data: createUserDto,
+    const hashedPassword = await this.bcrypt.hashPassword(
+      createUserDto.password,
+    );
+    const { username, email, role } = await this.prisma.users.create({
+      data: { ...createUserDto, password: hashedPassword },
     });
+    return { username, email, role };
   }
 
   async findAll() {


### PR DESCRIPTION
This pull request introduces a centralized and reusable bcrypt helper service for password hashing and comparison, and integrates it into the user creation flow. It also updates the user creation endpoint to return a more descriptive response. The most important changes are grouped below:

**Bcrypt Service Integration:**

* Added `bcrypt` and its type definitions to project dependencies in `package.json` to enable password hashing functionality. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R28) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R39)
* Implemented a global `BcryptModule` and `BcryptService` with methods for hashing and comparing passwords, and provided a basic unit test for the service. [[1]](diffhunk://#diff-7140cd58cf9a3c09d0307431c22c644d05a0b09ba1848c6425fbfcd9f6b07cfdR1-R9) [[2]](diffhunk://#diff-e28a89e77c9a00e0516b230fee1133a69554c7eed1ea5b65f5c4f5b01ac35049R1-R18) [[3]](diffhunk://#diff-e54a3bde785a415270ad489173fde3d6d3f7f97ce90e97c54d98766be257a076R1-R18)
* Registered `BcryptModule` as a dependency in `UsersModule` so it can be injected into the users service.

**User Creation Flow Enhancements:**

* Updated `UsersService` to use `BcryptService` for hashing passwords before saving users, and to only return non-sensitive user fields after creation.
* Modified the `UsersController` to return a success message and the created user data (excluding the password) when a new user is created.