### PR TITLE
implement onDestroyModule aka terminator service when application shutdown

### DIFF
--- a/src/common/helpers/db/prisma.service.ts
+++ b/src/common/helpers/db/prisma.service.ts
@@ -1,9 +1,23 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService extends PrismaClient implements OnModuleInit {
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
   async onModuleInit() {
+    Logger.log('Prisma connected', 'PrismaService');
     await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    Logger.log('Prisma disconnected', 'PrismaService');
+    await this.$disconnect();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ async function bootstrap() {
   // Register global exception filters for HTTP and Prisma errors.
   app.use(cookieParser());
   app.useGlobalFilters(new PrismaErrorFilter(), new HttpExceptionFilter());
+  app.enableShutdownHooks();
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
This pull request improves the lifecycle management of the Prisma database connection in the application. The changes ensure that the Prisma client logs connection and disconnection events, and that the application properly handles shutdown events to gracefully disconnect from the database.

Lifecycle management improvements:

* Updated `PrismaService` to implement both `OnModuleInit` and `OnModuleDestroy` interfaces, logging messages on connection and disconnection, and ensuring the Prisma client disconnects cleanly when the application shuts down. (`src/common/helpers/db/prisma.service.ts`)
* Enabled NestJS shutdown hooks in the application bootstrap function to trigger module destruction and resource cleanup on application shutdown. (`src/main.ts`)