### PR TITLE
Implementing join on CR table user/profile

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,8 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["relationJoins"]
 }
 
 model Users {

--- a/src/modules/profiles/profiles.controller.ts
+++ b/src/modules/profiles/profiles.controller.ts
@@ -30,8 +30,9 @@ export class ProfilesController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.profilesService.findOne(+id);
+  async findOne(@Param('id') id: string) {
+    const profile = await this.profilesService.findOne(+id);
+    return { profile };
   }
 
   // @Patch(':id')

--- a/src/modules/profiles/profiles.controller.ts
+++ b/src/modules/profiles/profiles.controller.ts
@@ -25,8 +25,8 @@ export class ProfilesController {
   }
 
   @Get()
-  findAll() {
-    return this.profilesService.findAll();
+  async findAll() {
+    return { profiles: await this.profilesService.findAll() };
   }
 
   @Get(':id')

--- a/src/modules/profiles/profiles.service.ts
+++ b/src/modules/profiles/profiles.service.ts
@@ -33,7 +33,17 @@ export class ProfilesService {
   }
 
   findAll() {
-    return `This action returns all profiles`;
+    return this.prisma.profiles.findMany({
+      include: {
+        user: {
+          select: {
+            username: true,
+            email: true,
+            role: true,
+          },
+        },
+      },
+    });
   }
 
   findOne(id: number) {

--- a/src/modules/profiles/profiles.service.ts
+++ b/src/modules/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/common/helpers/db/prisma.service';
 import { BcryptService } from 'src/common/helpers/bcrypt/bcrypt.service';
 import { CreateProfileDto } from './dto/create-profile.dto';
@@ -32,8 +32,8 @@ export class ProfilesService {
     return result;
   }
 
-  findAll() {
-    return this.prisma.profiles.findMany({
+  async findAll() {
+    return await this.prisma.profiles.findMany({
       include: {
         user: {
           select: {
@@ -46,8 +46,25 @@ export class ProfilesService {
     });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} profile`;
+  async findOne(id: number) {
+    const profile = await this.prisma.profiles.findUnique({
+      where: {
+        UserId: id,
+      },
+      include: {
+        user: {
+          select: {
+            username: true,
+            email: true,
+            role: true,
+          },
+        },
+      },
+    });
+    if (!profile) {
+      throw new NotFoundException('Profile user not found');
+    }
+    return profile;
   }
 
   // update(id: number, updateProfileDto: Prisma.ProfilesUpdateInput) {


### PR DESCRIPTION
This pull request enhances the profiles module by improving how profile data is retrieved and returned, and by introducing better error handling. The main changes include updating the service methods to fetch related user data, returning more structured API responses, and adding error handling for missing profiles.

**Profiles retrieval and response improvements:**

* Updated the `findAll` and `findOne` methods in `ProfilesService` to fetch related user information (`username`, `email`, `role`) and return the full profile data instead of placeholder strings.
* Modified the `ProfilesController` to return API responses wrapped in objects (`{ profiles: ... }` and `{ profile: ... }`) for consistency and clarity.

**Error handling:**

* Added a `NotFoundException` in `findOne` to handle cases where a profile does not exist, providing clearer error responses to API consumers. [[1]](diffhunk://#diff-dcdb77278c8f5b7eba4230ab52ad931bb85097778cf00b3ce5d051595acc3854L1-R1) [[2]](diffhunk://#diff-dcdb77278c8f5b7eba4230ab52ad931bb85097778cf00b3ce5d051595acc3854L35-R67)

**Prisma configuration:**

* Enabled the `relationJoins` preview feature in the Prisma client generator to support more advanced relation queries.