### PR TITLE
implementing delete join on profile

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,9 +39,9 @@ model Profiles {
   name   String @unique
   gender String
   age    Int
-  UserId Int    @unique
+  UserId Int?   @unique
 
-  user  Users   @relation(fields: [UserId], references: [id])
+  user  Users?  @relation(fields: [UserId], references: [id])
   posts Posts[]
 
   createdAt DateTime @default(now())

--- a/src/common/filters/prisma.filter.ts
+++ b/src/common/filters/prisma.filter.ts
@@ -21,6 +21,7 @@ const errorMap: Record<
     message: 'Resource already exists',
   }, // 409 CONFLICT
   P2005: { statusCode: HttpStatus.NOT_FOUND, message: 'Resource not found' }, // 400 NOT FOUND
+  P2025: { statusCode: HttpStatus.NOT_FOUND, message: 'No record was found' },
 };
 
 @Catch()
@@ -28,8 +29,11 @@ export class PrismaErrorFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost) {
     const context = host.switchToHttp();
     const response = context.getResponse<Response>();
+    const type = 'PrismaErrorInstance';
     let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
     let message = 'Internal server error';
+
+    Logger.debug(exception, 'INTERNAL_SERVER_ERROR');
 
     if (exception instanceof Prisma.PrismaClientKnownRequestError) {
       const { code } = exception;
@@ -42,6 +46,7 @@ export class PrismaErrorFilter implements ExceptionFilter {
     }
 
     response.status(statusCode).json({
+      type,
       message,
       statusCode,
     });

--- a/src/modules/profiles/profiles.controller.ts
+++ b/src/modules/profiles/profiles.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Delete,
   UsePipes,
+  HttpCode,
 } from '@nestjs/common';
 import { ProfilesService } from './profiles.service';
 import { ZodValidationPipe } from 'src/common/pipes/schema.validation.pipes';
@@ -44,7 +45,14 @@ export class ProfilesController {
   //   }  @P
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.profilesService.remove(+id);
+  async remove(@Param('id') id: string) {
+    const result = await this.profilesService.remove(+id);
+    return {
+      status: Object.prototype.hasOwnProperty.call(
+        result[0],
+        'count',
+      ) as boolean,
+      message: `Username ${result[1].username} succesfully deleted`,
+    };
   }
 }

--- a/src/modules/profiles/profiles.service.ts
+++ b/src/modules/profiles/profiles.service.ts
@@ -71,7 +71,18 @@ export class ProfilesService {
   //   return `This action updates a #${id} profile`;
   // }
 
-  remove(id: number) {
-    return `This action removes a #${id} profile`;
+  async remove(id: number) {
+    return await this.prisma.$transaction([
+      this.prisma.profiles.deleteMany({
+        where: {
+          UserId: id,
+        },
+      }),
+      this.prisma.users.delete({
+        where: {
+          id: id,
+        },
+      }),
+    ]);
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to error handling, enhances the profile deletion process, and updates the Prisma schema to better support nullable relationships. The main focus is on making the deletion of profiles more robust and informative, while also improving the error responses from the Prisma error filter.

**Error handling improvements:**

* Added handling for Prisma error code `P2025` (no record found) in the `errorMap` and included a `type` field in the error response for better debugging. Also added debug logging for internal server errors. (`src/common/filters/prisma.filter.ts`) [[1]](diffhunk://#diff-12c46b9b115fdd50e59109531aaf933ef69eca82cca408b80f5a6e5f356da9b3R24-R37) [[2]](diffhunk://#diff-12c46b9b115fdd50e59109531aaf933ef69eca82cca408b80f5a6e5f356da9b3R49)

**Profile deletion enhancements:**

* Updated the `remove` method in `ProfilesService` to use a Prisma transaction that deletes both the profile and the associated user in a single operation. (`src/modules/profiles/profiles.service.ts`)
* Modified the `remove` endpoint in `ProfilesController` to return a structured response indicating the deletion status and a success message with the username. (`src/modules/profiles/profiles.controller.ts`) [[1]](diffhunk://#diff-0c7f314c1ecfaa041d2f1cd7c3784ce73a846c28776f1d710be70a94647ace89L47-R56) [[2]](diffhunk://#diff-0c7f314c1ecfaa041d2f1cd7c3784ce73a846c28776f1d710be70a94647ace89R9)

**Prisma schema update:**

* Made the `UserId` field in the `Profiles` model nullable and updated the relation to the `Users` model to be optional, allowing for more flexible profile-user associations. (`prisma/schema.prisma`)