### PR TITLE
chore: implementing role guard for ADMIN and USER

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guards';
 import { ProfilesModule } from './modules/profiles/profiles.module';
+import { RolesGuard } from './common/guards/roles.guards';
 
 @Module({
   imports: [AuthModule, UsersModule, ProfilesModule],
@@ -15,6 +16,10 @@ import { ProfilesModule } from './modules/profiles/profiles.module';
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard,
     },
   ],
 })

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { Reflector } from '@nestjs/core';
+
+export const Roles = Reflector.createDecorator<string[]>();

--- a/src/common/guards/roles.guards.ts
+++ b/src/common/guards/roles.guards.ts
@@ -1,0 +1,30 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Roles } from '../decorators/roles.decorator';
+import { RequestUser } from 'src/modules/auth/request-auth.interface';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext) {
+    const roles = this.reflector.get(Roles, context.getHandler());
+    const request: RequestUser = context.switchToHttp().getRequest();
+
+    Logger.debug(roles, 'RolesDecorator');
+    Logger.debug(request.user, 'UserInfo');
+
+    if (!roles) {
+      return true;
+    }
+    const status = roles.some((role) => role === request.user.role);
+
+    Logger.debug(status, 'UserRoleIncludedStatus');
+    return status;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   // Register global exception filters for HTTP and Prisma errors.
   app.use(cookieParser());
+
   app.useGlobalFilters(new PrismaErrorFilter(), new HttpExceptionFilter());
   app.enableShutdownHooks();
   await app.listen(process.env.PORT ?? 3000);

--- a/src/modules/profiles/profiles.controller.ts
+++ b/src/modules/profiles/profiles.controller.ts
@@ -14,6 +14,7 @@ import {
   type CreateProfileDto,
   createProfileSchema,
 } from './dto/create-profile.dto';
+import { Roles } from 'src/common/decorators/roles.decorator';
 
 @Controller('profiles')
 export class ProfilesController {
@@ -30,6 +31,7 @@ export class ProfilesController {
     return { profiles: await this.profilesService.findAll() };
   }
 
+  @Roles(['USER', 'ADMIN'])
   @Get(':id')
   async findOne(@Param('id') id: string) {
     const profile = await this.profilesService.findOne(+id);


### PR DESCRIPTION
This pull request introduces a role-based authorization system to the application by adding a `RolesGuard` and a `@Roles` decorator, and integrating them into the global guard chain. This allows endpoints to be protected based on user roles, making authorization more flexible and secure. Additionally, the role-based guard is demonstrated in the `ProfilesController`.

**Role-based Authorization System**

* Added a new `RolesGuard` in `src/common/guards/roles.guards.ts` that checks if the authenticated user's role matches the required roles for an endpoint using the `@Roles` decorator. The guard uses the NestJS `Reflector` to access metadata and is registered as a global guard in `AppModule`. [[1]](diffhunk://#diff-636be7daec473e7cf187c3bd73625ef2446641357e82619b5425346817c74d85R1-R30) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R9) [[3]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R20-R23)
* Created a `@Roles` decorator in `src/common/decorators/roles.decorator.ts` to specify allowed roles on controller methods.
* Registered the new `RolesGuard` as a global guard in `AppModule`, ensuring all routes can be protected by role-based authorization.

**Controller Integration Example**

* Applied the `@Roles(['USER', 'ADMIN'])` decorator to the `findOne` method in `ProfilesController`, restricting access to users with either the `USER` or `ADMIN` role. [[1]](diffhunk://#diff-0c7f314c1ecfaa041d2f1cd7c3784ce73a846c28776f1d710be70a94647ace89R17) [[2]](diffhunk://#diff-0c7f314c1ecfaa041d2f1cd7c3784ce73a846c28776f1d710be70a94647ace89R34)

**Other Minor Changes**

* Minor formatting adjustment in `src/main.ts` (added a blank line for readability).